### PR TITLE
store the .bak files in the backup folder

### DIFF
--- a/docs/analysis-services/multidimensional-tutorial/install-sample-data-and-projects.md
+++ b/docs/analysis-services/multidimensional-tutorial/install-sample-data-and-projects.md
@@ -50,7 +50,7 @@ To install the database, do the following:
   
 1.  Download an [AdventureWorksDW](https://github.com/Microsoft/sql-server-samples/releases/tag/adventureworks) database backup from GitHub.  
   
-2.  Copy the backup file to the data directory of the local SQL Server Database Engine instance.
+2.  Copy the backup file to the backup directory of the local SQL Server Database Engine instance.
   
 3.  Start SQL Server Management Studio and connect to the Database Engine instance.  
   


### PR DESCRIPTION
The .bak files available to be download from Github repo is to be stored in the backup folder and not the data folder, as the SSMS doesn't recognize the backup file if stored in the data folder while attempting to restore the database