### PR TITLE
Update 'RowsetSerializationLimit with warning on 0

### DIFF
--- a/docs/analysis-services/server-properties/olap-properties.md
+++ b/docs/analysis-services/server-properties/olap-properties.md
@@ -1,6 +1,6 @@
 ---
 title: "Analysis Services OLAP properties | Microsoft Docs"
-ms.date: 09/07/2019
+ms.date: 03/12/2020
 ms.prod: sql
 ms.technology: analysis-services
 ms.custom: 
@@ -269,9 +269,7 @@ Approach for estimating dimension cache requirements:
  An advanced property that you should not change, except under the guidance of [!INCLUDE[msCoName](../../includes/msconame-md.md)] support.  
  
  **RowsetSerializationLimit**   
- Applies to Azure Analysis Services and SQL Server 2019 and later only. Limits the number of rows returned in a rowset to clients. Default value is -1, meaning no limit is applied. Applies to both DAX and MDX queries. It can be used to protect server resources from extensive data export. Queries submitted to the server that exceed the limit are cancelled and an error is returned.  
- 
-This also applies to XMLA queries, which return a rowset of size >0. Setting this value to 0 will cause any queries returning a rowset to fail. This includes an XMLA query to change the value of this property. If you change this property's value to 0, you will have to edit the msmdsrv.ini config file by hand and restart the SSAS service. This will require remote administrative access to the VM hosting SSAS.
+ Applies to Azure Analysis Services and SQL Server 2019 and later only. Limits the number of rows returned in a rowset to clients. Default value is -1, meaning no limit is applied. Applies to both DAX and MDX queries. It can be used to protect server resources from extensive data export. Queries submitted to the server that exceed the limit are cancelled and an error is returned. **Warning:** Do not set to 0, which can result in errors for common operations and could prevent further server access by Analysis Services server administrators.
 
  **UseCalculationCacheRegistry**  
  An advanced property that you should not change, except under the guidance of [!INCLUDE[msCoName](../../includes/msconame-md.md)] support.  

--- a/docs/analysis-services/server-properties/olap-properties.md
+++ b/docs/analysis-services/server-properties/olap-properties.md
@@ -270,6 +270,8 @@ Approach for estimating dimension cache requirements:
  
  **RowsetSerializationLimit**   
  Applies to Azure Analysis Services and SQL Server 2019 and later only. Limits the number of rows returned in a rowset to clients. Default value is -1, meaning no limit is applied. Applies to both DAX and MDX queries. It can be used to protect server resources from extensive data export. Queries submitted to the server that exceed the limit are cancelled and an error is returned.  
+ 
+This also applies to XMLA queries, which return a rowset of size >0. Setting this value to 0 will cause any queries returning a rowset to fail. This includes an XMLA query to change the value of this property. If you change this property's value to 0, you will have to edit the msmdsrv.ini config file by hand and restart the SSAS service. This will require remote administrative access to the VM hosting SSAS.
 
  **UseCalculationCacheRegistry**  
  An advanced property that you should not change, except under the guidance of [!INCLUDE[msCoName](../../includes/msconame-md.md)] support.  


### PR DESCRIPTION
Setting the property value of OLAP\Query\RowsetSerializationLimit to 0
will cause all queries returning rowsets to fail. This includes the
XMLA queries to change exactly this setting, leaving the SSAS instance
in a nigh-unusable state.

The only way that it seems possible to revert such a change (to 0) is
to manually edit the config file for SSAS and restart the service.