### PR TITLE
Documented Azure AD access token usage

### DIFF
--- a/docs/analysis-services/instances/connection-string-properties-analysis-services.md
+++ b/docs/analysis-services/instances/connection-string-properties-analysis-services.md
@@ -91,7 +91,7 @@ Cube name or perspective name. A database can contain multiple cubes and perspec
 
 ::: moniker range="asallproducts-allversions || azure-analysis-services-current || power-bi-premium-current"
 
-Azure Analysis Services and Power BI Premium use Azure Active Directory - Universal with MFA (recommended), Azure Active Directory authentication with username and password, or Windows authentication.
+Azure Analysis Services and Power BI Premium use Azure Active Directory - Universal with MFA (recommended), Azure Active Directory authentication with username and password, Azure Active Directory access tokens (see [User ID and Password below](#user-idpassword)), or Windows authentication.
 
 ::: moniker-end
 
@@ -197,6 +197,7 @@ User ID and Password properties provide the appropriate credentials to the serve
 - When connecting over TCP to SSAS, the client library will impersonate the Windows user using the specified username and password, and then connect as usual to the server.
 - When connecting over HTTP(S) to SSAS, the credentials are provided to the web server based on the authentication mode configured on the web server, for example Basic auth or Windows auth. The web server will perform the appropriate Windows impersonation before connecting to the SSAS server, therefore providing the correct credentials flow to the server.
 - When connecting to Azure AS or Power BI Premium, the User ID and Password are used to obtain an Azure Active Directory (AAD) token which is then presented to the service during authentication. Azure Active Directory (AAD) may also require multi-factor authentication (MFA), which can require additional user interaction before the token can be generated.
+- If you have already acquired a valid Azure Active Directory access token from your own application (e.g. for an end user, a Service Principal or even a [Managed identity for Azure resources](https://docs.microsoft.com/azure/active-directory/managed-identities-azure-resources/overview), you can omit the **User ID** property and use the access token in the **Password** property. This is supported for access tokens acquired interactively for an end user, as well as using the [OAuth 2.0 On-Behalf-Of flow](https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow) (for example, from a middle-tier web application connecting to Analysis Services on behalf of the end user).
 
 **Note:** "User ID" has an embedded space. An alternate alias for User ID is **UID** and an alternate alias for Password is **PWD**.  
 


### PR DESCRIPTION
The approach of omitting the "User ID" and using an Azure AD access token in the "Password" property is supported per PG but not documented, want to ensure customers understand this is a valid and supported mechanism.