### PR TITLE
Detach/Attach is not available for Standard

### DIFF
--- a/docs/analysis-services/analysis-services-features-supported-by-the-editions-of-sql-server-2016.md
+++ b/docs/analysis-services/analysis-services-features-supported-by-the-editions-of-sql-server-2016.md
@@ -21,7 +21,8 @@ This article describes features supported by different editions of SQL Server 20
 |Feature|Enterprise|Standard|Web|Express with Advanced Services|Express with Tools|Express|Developer|  
 |-------------|----------------|--------------|---------|------------------------------------|------------------------|-------------|---------------|  
 |Scalable shared databases|Yes||||||Yes|  
-|Backup/Restore & Attach/Detach databases|Yes|Yes|||||Yes|  
+|Backup/Restore|Yes|Yes|||||Yes|
+|Attach/Detach databases|Yes||||||Yes|  
 |Synchronize databases|Yes||||||Yes|  
 |Failover cluster instances|Yes<br /><br /> Number of nodes is the operating system maximum|Yes<br /><br /> Support for 2 nodes|||||Yes<br /><br /> Number of nodes is the operating system maximum|  
 |Programmability (AMO, ADOMD.Net, OLEDB, XML/A, ASSL, TMSL)|Yes|Yes|||||Yes|  


### PR DESCRIPTION
I (junche@microsoft.com) am from Microsoft CSS. We got the confirmation from Analysis Services product team that this is a doc bug. So request to fix it:

From: Akshai Mirchandani <akshaim@microsoft.com> 
Sent: Thursday, March 24, 2022 6:30 AM
To: Yuto Watarai <Yuto.Watarai@microsoft.com>; Pascal Deliot <Pascal.Deliot@microsoft.com>; Analysis Services Technical Discussion <olaptalk@microsoft.com>; Owen Duncan <owend@microsoft.com>
Cc: CSS Japan - Data & AI BAP/SQL BI <jpdsdbapbi@microsoft.com>
Subject: RE: [SSAS on SQL VM | Standard] an error occurs when attaching or detaching.

Attach/Detach is *not* supported in Standard. The docs will need to be updated if they don’t say that – Backup/Restore is supported, and its problematic that that the two capabilities are bundled into the same line.