### PR TITLE
LinkFix: bi-shared-docs (2022-08)

### DIFF
--- a/docs/analysis-services/instances/configure-the-windows-firewall-to-allow-analysis-services-access.md
+++ b/docs/analysis-services/instances/configure-the-windows-firewall-to-allow-analysis-services-access.md
@@ -30,7 +30,7 @@ monikerRange: "asallproducts-allversions || >= sql-analysis-services-2016"
  Although the default instance of [!INCLUDE[ssASnoversion](../includes/ssasnoversion-md.md)] listens on TCP port 2383, you can configure the server to listen on a different fixed port, connecting to the server in this format: \<servername>:\<portnumber>. 
 
 > [!NOTE]  
-> You cannot use a non-default port for Analysis services if you need to connect to your instance using Kerberos. For more information review [SPN registration for SSAS instances listening on fixed ports](https://docs.microsoft.com/analysis-services/instances/spn-registration-for-an-analysis-services-instance#bkmk_spnFixedPorts)
+> You cannot use a non-default port for Analysis services if you need to connect to your instance using Kerberos. For more information review [SPN registration for SSAS instances listening on fixed ports](/analysis-services/instances/spn-registration-for-an-analysis-services-instance#bkmk_spnFixedPorts)
   
  Only one TCP port can be used by an [!INCLUDE[ssASnoversion](../includes/ssasnoversion-md.md)] instance. On computers having multiple network cards or multiple IP addresses, [!INCLUDE[ssASnoversion](../includes/ssasnoversion-md.md)] listens on one TCP port for all IP addresses assigned or aliased to the computer. If you have specific multi-port requirements, consider configuring [!INCLUDE[ssASnoversion](../includes/ssasnoversion-md.md)] for HTTP access. You can then set up multiple HTTP endpoints on whatever ports you choose. See [Configure HTTP Access to Analysis Services on Internet Information Services &#40;IIS&#41; 8.0](../../analysis-services/instances/configure-http-access-to-analysis-services-on-iis-8-0.md).  
   
@@ -229,4 +229,3 @@ monikerRange: "asallproducts-allversions || >= sql-analysis-services-2016"
  [SQL Server Browser Service &#40;Database Engine and SSAS&#41;](/sql/database-engine/configure-windows/sql-server-browser-service-database-engine-and-ssas)   
  [Start, Stop, Pause, Resume, Restart the Database Engine, SQL Server Agent, or SQL Server Browser Service](/sql/database-engine/configure-windows/start-stop-pause-resume-restart-sql-server-services)   
  [Configure a Windows Firewall for Database Engine Access](/sql/database-engine/configure-windows/configure-a-windows-firewall-for-database-engine-access)  
-  

--- a/docs/analysis-services/instances/spn-registration-for-an-analysis-services-instance.md
+++ b/docs/analysis-services/instances/spn-registration-for-an-analysis-services-instance.md
@@ -161,10 +161,9 @@ Setspn -s msolapsvc.3/<virtualname.FQDN > <domain user account>
  [Microsoft BI Authentication and Identity Delegation](/previous-versions/sql/sql-server-2012/dn186184(v=msdn.10))   
  [Mutual Authentication Using Kerberos](/windows/win32/ad/mutual-authentication-using-kerberos)    
  [Service Principal Names (SPNs) SetSPN Syntax (Setspn.exe)](https://social.technet.microsoft.com/wiki/contents/articles/717.service-principal-names-spns-setspn-syntax-setspn-exe.aspx)   
- [SetSPN](https://docs.microsoft.com/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/cc731241(v=ws.11))   
- [Service Accounts Step-by-Step Guide](https://docs.microsoft.com/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/dd548356(v=ws.10))   
+ [SetSPN](/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/cc731241(v=ws.11))   
+ [Service Accounts Step-by-Step Guide](/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/dd548356(v=ws.10))   
  [Configure Windows Service Accounts and Permissions](/sql/database-engine/configure-windows/configure-windows-service-accounts-and-permissions)   
  [How to use SPNs when you configure Web applications that are hosted on Internet Information Services](https://support.microsoft.com/kb/929650)   
  [what's new in service accounts](https://technet.microsoft.com/library/dd367859\(WS.10\).aspx)   
  [Configure Kerberos authentication for SharePoint 2010 Products (white paper)](/previous-versions/office/sharepoint-server-2010/ff829837(v=office.14))  
-  


### PR DESCRIPTION
This PR is the result of running a Link Repair script on the included content. This script is primarily being run to clean up links to function correctly in Air Gapped Clouds (AGC). Here's a breakdown of what the script that generated the changes in this PR fixes: 

 

- docs.microsoft.com Fully Qualified Domain Name (FQDN) Links to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

- azure.microsoft.com/documentation/articles that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

- All known flavors of MSDN/TechNet domains (we know of 8 or 9 now) that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

  - This also includes cleanup of the appended query string for MSDN (redirectedfrom=MSDN). 

- Fixes articles that are redirected in `.openpublishing.redirection.json` and updates the link to the current final location (this has a lot of customer usability fixes). 

 

Please note the [Contributor Guide: Links](https://review.docs.microsoft.com/en-us/help/contribute/links-how-to?branch=master) has been updated with the following link-type preference order: 

 

``` 

By order of preference, links hosted on Docs should be Relative if they are in the same repository and docset. If they are in a different docset, even if in the same repository, they should be Site Relative. Links to content hosted on Docs shouldn't use a complete URL, otherwise known as Fully Qualified Domain Names (FQDN). Using a complete URL from Docs to other content on Docs will cause that link to be non-functional in air-gap environments. 

``` 